### PR TITLE
Fix: solve github action error when doing CI/CD

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    # google auth 설정
+    - name: google auth
+      uses: "google-github-actions/auth@v1"
+      with:
+        credentials_json: "${{ secrets.SERVICE_ACCOUNT_KEY }}"
+
     # gcloud CLI 설정
     - uses: google-github-actions/setup-gcloud@v0
       with:


### PR DESCRIPTION
## PR 제목
CI/CD 진행 중 Github Action에서 발생하는 에러 해결

### PR 생성일시
* 2023/07/18

### PR 내용
1. CI/CD 진행 중 "Publish" 파트에서 에러 발생
2. 해결을 위해 "google auth"를 github action에 추가

### PR 유의사항